### PR TITLE
Update AccessTokenService.cs

### DIFF
--- a/Source/Digst.OioIdws.Rest.Client/AccessToken/AccessTokenService.cs
+++ b/Source/Digst.OioIdws.Rest.Client/AccessToken/AccessTokenService.cs
@@ -40,7 +40,7 @@ namespace Digst.OioIdws.Rest.Client.AccessToken
 
             using (var stream = new MemoryStream())
             {
-                using (var writer = XmlWriter.Create(stream))
+                using (var writer = XmlWriter.Create(stream, new XmlWriterSettings() { Encoding = new System.Text.UTF8Encoding(false) }))
                 {
                     securityToken.TokenXml.WriteTo(writer);
                 }


### PR DESCRIPTION
Updated AccessTokenService XmlWriter to use UTF8Encoding WITHOUT BOM.

When using this package to connect to ServicePlatformed we ran into an issue where the XML was encoded to B64 with a BOM invisible sign in front of the string.

From https://stackoverflow.com/a/15583729 :

The issue is due to the fact that you are using the static [UTF8 property](http://msdn.microsoft.com/en-us/library/system.text.encoding.utf8.aspx) on the [Encoding class](http://msdn.microsoft.com/en-us/library/86hf4sb8.aspx).

When the [GetPreamble method](http://msdn.microsoft.com/en-us/library/system.text.encoding.getpreamble.aspx) is called on the instance of the Encoding class returned by the UTF8 property, it returns the byte order mark (the byte array of three characters) and is written to the stream before any other content is written to the stream (assuming a new stream).

You can avoid this by creating the instance of the [UTF8Encoding class](http://msdn.microsoft.com/en-us/library/system.text.utf8encoding.aspx) yourself, like so:

// As before.
this.Writer = new StreamWriter(this.Stream, 
    // Create yourself, passing false will prevent the BOM from being written.
    new System.Text.UTF8Encoding());
As per the documentation for the [default parameterless constructor](http://msdn.microsoft.com/en-us/library/s756abs9.aspx) (emphasis mine):

This constructor creates an instance that does not provide a Unicode byte order mark and does not throw an exception when an invalid encoding is detected.

This means that the call to GetPreamble will return an empty array, and therefore no BOM will be written to the underlying stream.